### PR TITLE
add "export" on GVM_CANDIDATE_COUNT

### DIFF
--- a/src/main/bash/gvm-init.sh
+++ b/src/main/bash/gvm-init.sh
@@ -165,7 +165,7 @@ fi
 # In bash arrays are zero index based, in zsh they are 1 based(!)
 gvm_set_candidates
 if [[ -z "$ZSH_VERSION" ]]; then
-	GVM_CANDIDATE_COUNT=${#GVM_CANDIDATES[@]}
+	export GVM_CANDIDATE_COUNT=${#GVM_CANDIDATES[@]}
 else
 	GVM_CANDIDATE_COUNT=${#GVM_CANDIDATES}
 fi


### PR DESCRIPTION
The `gvm current` command was failing (in a bash environment) with GVM_CANDIDATE_COUNT having no value.

The insertion of an "export" on the assignment of this variable fixes the problem.