### PR TITLE
Fix the issue that the "Outdated:" label is not displayed in some cases.

### DIFF
--- a/src/main/bash/gvm-outdated.sh
+++ b/src/main/bash/gvm-outdated.sh
@@ -46,7 +46,7 @@ function __gvmtool_outdated {
                 ;;
             *)
                 if [ -n "${outdated}" ]; then
-                    [ ${installed_count} -eq 0 ] && echo "Outdated:"
+                    [ ${outdated_count} -eq 0 ] && echo "Outdated:"
                     echo "${outdated}"
                     (( outdated_count += 1 ))
                 fi


### PR DESCRIPTION
Sorry, but the current outdated command can't print the "Outdated" label properly in some case: In order, the first candidate is not outdated, but the after-second candidate is outdated.

It's caused by the wrong condition.