### PR TITLE
Use ${GVM_DIR} instead of hardcoded .gvm

### DIFF
--- a/src/main/bash/gvm-current.sh
+++ b/src/main/bash/gvm-current.sh
@@ -19,11 +19,11 @@
 function __gvmtool_determine_current_version {
 	CANDIDATE="$1"
 	if [[ "${solaris}" == true ]]; then
-		CURRENT=$(echo $PATH | gsed -r "s|.gvm/${CANDIDATE}/([^/]+)/bin|!!\1!!|1" | gsed -r "s|^.*!!(.+)!!.*$|\1|g")
+		CURRENT=$(echo $PATH | gsed -r "s|${GVM_DIR}/${CANDIDATE}/([^/]+)/bin|!!\1!!|1" | gsed -r "s|^.*!!(.+)!!.*$|\1|g")
 	elif [[ "${darwin}" == true ]]; then
-		CURRENT=$(echo $PATH | sed -E "s|.gvm/${CANDIDATE}/([^/]+)/bin|!!\1!!|1" | sed -E "s|^.*!!(.+)!!.*$|\1|g")
+		CURRENT=$(echo $PATH | sed -E "s|${GVM_DIR}/${CANDIDATE}/([^/]+)/bin|!!\1!!|1" | sed -E "s|^.*!!(.+)!!.*$|\1|g")
 	else
-		CURRENT=$(echo $PATH | sed -r "s|.gvm/${CANDIDATE}/([^/]+)/bin|!!\1!!|1" | sed -r "s|^.*!!(.+)!!.*$|\1|g")
+		CURRENT=$(echo $PATH | sed -r "s|${GVM_DIR}/${CANDIDATE}/([^/]+)/bin|!!\1!!|1" | sed -r "s|^.*!!(.+)!!.*$|\1|g")
 	fi
 
 	if [[ "${CURRENT}" == "current" ]]; then


### PR DESCRIPTION
__gvmtool_determine_current_version currently has ".gvm" hardcoded instead of using the GVM_DIR env var, this pull request fixes that.