### PR TITLE
Fix init from missing the last few candidates

### DIFF
--- a/src/main/bash/gvm-init.sh
+++ b/src/main/bash/gvm-init.sh
@@ -170,7 +170,7 @@ if [[ "${GVM_INIT}" != "true" ]]; then
     # The candidates are assigned to an array for zsh compliance, a list of words is not iterable
     # Arrays are the only way, but unfortunately zsh arrays are not backward compatible with bash
     # In bash arrays are zero index based, in zsh they are 1 based(!)
-    for (( i=0; i <= ${#GVM_CANDIDATES}; i++ )); do
+    for (( i=0; i <= ${#GVM_CANDIDATES[*]}; i++ )); do
         # Eliminate empty entries due to incompatibility
         if [[ -n ${GVM_CANDIDATES[${i}]} ]]; then
             CANDIDATE_NAME="${GVM_CANDIDATES[${i}]}"

--- a/src/test/groovy/gvm/specs/InitialisationSpec.groovy
+++ b/src/test/groovy/gvm/specs/InitialisationSpec.groovy
@@ -1,0 +1,74 @@
+package gvm.specs
+
+import gvm.env.BashEnv
+import gvm.env.GvmBashEnvBuilder
+import gvm.stubs.CurlStub
+import spock.lang.Specification
+
+import static gvm.utils.TestUtils.prepareBaseDir
+
+class InitialisationSpec extends Specification {
+
+    CurlStub curlStub
+    BashEnv bash
+
+    File gvmBaseDir
+    String gvmDotDir
+    String bootstrap
+
+    void setup(){
+        gvmBaseDir = prepareBaseDir()
+        gvmDotDir = "${gvmBaseDir.absolutePath}/.gvm"
+        bootstrap = "${gvmDotDir}/bin/gvm-init.sh"
+        curlStub = CurlStub.prepareIn(new File(gvmBaseDir, "bin"))
+    }
+
+    void "should include all candidates in PATH"(){
+        given: 'a working gvm installation with many candidates'
+        def candidates = [
+                "asciidoctorj",
+                "crash",
+                "gaiden",
+                "glide",
+                "gradle",
+                "grails",
+                "griffon",
+                "groovy",
+                "groovyserv",
+                "jbake",
+                "jbossforge",
+                "lazybones",
+                "springboot",
+                "vertx",
+        ]
+        bash = GvmBashEnvBuilder
+                .create(gvmBaseDir)
+                .withAvailableCandidates(candidates)
+                .withCandidates(candidates)
+                .withCurlStub(curlStub)
+                .withVersionToken("x.y.z")
+                .build()
+        bash.start()
+        bash.execute("source $bootstrap")
+        bash.resetOutput()
+
+        when: 'obtaining and parsing PATH'
+        bash.execute('echo $PATH')
+        def pathParts = bash.output.split(':')
+        def pathElementMatcher = ~/$gvmDotDir\/([^\/]+)\/.*/
+        def includedCandidates = pathParts
+                .collect { it =~ pathElementMatcher }
+                .findAll { it }
+                .collect { it[0][1] }
+
+        then:
+        def missingCandidates = (candidates - includedCandidates)
+        missingCandidates.empty
+    }
+
+    void cleanup(){
+        println bash.output
+        bash.stop()
+        assert gvmBaseDir.deleteDir()
+    }
+}


### PR DESCRIPTION
In bash, `${#ARR}` returns the length of the string in the first slot.
'asciidoctorj' has a length of 12, which was working until more
candidates were added.

`${#ARR[*]}` is the correct way to return the length of an array in
bash. Thankfully, this works in ZSH as well.

This issue is preventing `vertx` from appearing on my path.

To demonstrate, you may run these commands in your shell:

```
$ echo ${GVM_CANDIDATES[*]}
asciidoctorj crash gaiden glide gradle grails griffon groovy groovyserv 
jbake jbossforge lazybones springboot vertx

$ echo ${#GVM_CANDIDATES}
12

$ echo ${#GVM_CANDIDATES[*]}
14
```