### PR TITLE
Fix 'Running the server locally' section in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Add any other candidates that you might require.
 Next, prepare the local GVM environment by building and starting the server.
 
 	$ ./gradlew
-	$ contrib/run.sh
+	$ bin/run.sh
 
 This will start the server on localhost:8080
 


### PR DESCRIPTION
That folder was renamed in here febef222e610040b8619efed02cdbad9d99ed56e